### PR TITLE
chg: configurado target Windows 64bits #S-12793049

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.dll filter=lfs diff=lfs merge=lfs -text
+*.lib filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,10 @@
 *.la
 *.lai
 *.so
-*.dll
 *.dylib
+*.exp
+*.ilk
+*.pdb
 
 # Qt-es
 

--- a/build/debug/win32/quazip.dll
+++ b/build/debug/win32/quazip.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3aad8fb8a0462011965347b8f84d904cfb2a5dd4ce42de60677236374209fa8a
+size 164352

--- a/build/debug/win32/quazip.lib
+++ b/build/debug/win32/quazip.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1c3b4341010bf9410d28150a6e626edb1b2c9ce44d3134d4d6712f8dafb0ffd
+size 37632

--- a/build/debug/win64/quazip.dll
+++ b/build/debug/win64/quazip.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4959c25e4db4ff9f153074429dcffd7624ffcdb1966c947e2ca215b94b23408c
+size 210432

--- a/build/debug/win64/quazip.lib
+++ b/build/debug/win64/quazip.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4cd21e1233739c930a81641747f71954ead4f706892a65f46016ca7c110c993
+size 38468

--- a/build/release/win32/quazip.dll
+++ b/build/release/win32/quazip.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ad25ce60a59cd95dbaa13a2c638569499fb37d9ea7d41274a229b695ad7127b
+size 74752

--- a/build/release/win32/quazip.lib
+++ b/build/release/win32/quazip.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42ac6a15bbe7fd19a78c34b998d478a99b02d70f6dd2cd45466451c94af5e7d8
+size 37632

--- a/build/release/win64/quazip.dll
+++ b/build/release/win64/quazip.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d3f340b4c22e21e24751f464e11096aa91ac89f721fd88d512e8778c4a32424
+size 90624

--- a/build/release/win64/quazip.lib
+++ b/build/release/win64/quazip.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2481bf54c914f5d63f679604456db59e1a5e1c92614b1ebfe7554d639bd5e3c3
+size 38468

--- a/src/quazip.pro
+++ b/src/quazip.pro
@@ -11,7 +11,7 @@ DEFINES += "WINVER=0x0501"
 DEFINES += "_WIN32_WINNT=0x0501"
 
 win32 {
-    ZLIBDIR = F:\Qt\5.5\Src\qtbase\src\3rdparty\zlib
+    ZLIBDIR = $$[QT_INSTALL_PREFIX]/../Src/qtbase/src/3rdparty/zlib
 }
 INCLUDEPATH += $${ZLIBDIR}
 
@@ -50,4 +50,20 @@ win32 {
     target.path=$$PREFIX/lib
     INSTALLS += headers target
 
+}
+
+!contains(QMAKE_TARGET.arch, x86_64) {
+    CONFIG(release, debug|release) {
+        DESTDIR = $${_PRO_FILE_PWD_}/../build/release/win32
+    }
+    else:CONFIG(debug, debug|release){
+        DESTDIR = $${_PRO_FILE_PWD_}/../build/debug/win32
+    }
+} else {
+    CONFIG(release, debug|release) {
+        DESTDIR = $${_PRO_FILE_PWD_}/../build/release/win64
+    }
+    else:CONFIG(debug, debug|release){
+        DESTDIR = $${_PRO_FILE_PWD_}/../build/debug/win64
+    }
 }


### PR DESCRIPTION
Arquivos binários gerados foram incluídos para que possam ser utilizados pelo uel+.
